### PR TITLE
add condition to show menu

### DIFF
--- a/lib/solidus_stock_transfers/engine.rb
+++ b/lib/solidus_stock_transfers/engine.rb
@@ -17,7 +17,8 @@ module SolidusStockTransfers
         config.menu_items.insert idx, config.class::MenuItem.new(
           [:stock_transfers],
           'exchange',
-          url: :admin_stock_transfers_path
+          url: :admin_stock_transfers_path,
+          condition: -> { can?(:admin, :stock_transfers) }
         )
       end
     end


### PR DESCRIPTION
Currently menu shows in admin even when user is not logged. This PR fix that.